### PR TITLE
Add home link layouts for subpages

### DIFF
--- a/src/app/clase-gratis/layout.tsx
+++ b/src/app/clase-gratis/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function ClaseGratisLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Link
+        href="/"
+        className="mt-6 inline-block bg-gray-200 text-black py-2 px-4 rounded-xl text-center hover:bg-gray-300 transition"
+      >
+        ← Volver al inicio
+      </Link>
+      {children}
+    </>
+  );
+}

--- a/src/app/entrenamiento-semanal/layout.tsx
+++ b/src/app/entrenamiento-semanal/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function EntrenamientoSemanalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Link
+        href="/"
+        className="mt-6 inline-block bg-gray-200 text-black py-2 px-4 rounded-xl text-center hover:bg-gray-300 transition"
+      >
+        ← Volver al inicio
+      </Link>
+      {children}
+    </>
+  );
+}

--- a/src/app/entrenamientos/layout.tsx
+++ b/src/app/entrenamientos/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function EntrenamientosLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Link
+        href="/"
+        className="mt-6 inline-block bg-gray-200 text-black py-2 px-4 rounded-xl text-center hover:bg-gray-300 transition"
+      >
+        ← Volver al inicio
+      </Link>
+      {children}
+    </>
+  );
+}

--- a/src/app/gracias/layout.tsx
+++ b/src/app/gracias/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function GraciasLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Link
+        href="/"
+        className="mt-6 inline-block bg-gray-200 text-black py-2 px-4 rounded-xl text-center hover:bg-gray-300 transition"
+      >
+        ← Volver al inicio
+      </Link>
+      {children}
+    </>
+  );
+}

--- a/src/app/reservar/layout.tsx
+++ b/src/app/reservar/layout.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function ReservarLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Link
+        href="/"
+        className="mt-6 inline-block bg-gray-200 text-black py-2 px-4 rounded-xl text-center hover:bg-gray-300 transition"
+      >
+        ← Volver al inicio
+      </Link>
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap subpages in their own layouts
- add `← Volver al inicio` `Link` at the top of each subpage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872298fb160832da6d017d384c8490c