### PR TITLE
Cleanup suscribirme route

### DIFF
--- a/src/app/entrenamiento-semanal/page.tsx
+++ b/src/app/entrenamiento-semanal/page.tsx
@@ -1,0 +1,26 @@
+export default function EntrenamientoSemanal() {
+  return (
+    <main className="min-h-screen bg-black text-white flex flex-col items-center justify-center p-8">
+      <h1 className="text-3xl font-bold mb-4 text-center">Unite semanalmente a los entrenamientos</h1>
+      <form action="https://formspree.io/f/mayvlkge" method="POST" className="w-full max-w-md flex flex-col gap-4">
+        <input
+          type="text"
+          name="name"
+          placeholder="Nombre"
+          required
+          className="p-2 rounded text-black"
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder="Email"
+          required
+          className="p-2 rounded text-black"
+        />
+        <button type="submit" className="bg-yellow-400 text-black py-2 rounded hover:bg-yellow-300 transition">
+          Enviar
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
           <a href="/reservar" className="bg-gray-200 text-black py-3 rounded-xl text-center">
             Reservar horario
           </a>
-          <a href="/suscribirme" className="bg-gray-200 text-black py-3 rounded-xl text-center">
+          <a href="/entrenamiento-semanal" className="bg-gray-200 text-black py-3 rounded-xl text-center">
             Unirme semanalmente
           </a>
           <button

--- a/src/app/suscribirme/page.tsx
+++ b/src/app/suscribirme/page.tsx
@@ -1,7 +1,0 @@
-export default function Suscribirme() {
-  return (
-    <main className="min-h-screen bg-black text-white flex items-center justify-center">
-      <h1 className="text-3xl font-bold">Unite semanalmente a los entrenamientos</h1>
-    </main>
-  );
-}


### PR DESCRIPTION
## Summary
- remove old `/suscribirme` page
- add `/entrenamiento-semanal` page with subscription form
- update home page link to `/entrenamiento-semanal`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6871bbbcf2f0832dbba02c37f3c176e4