### PR TITLE
Improve mobile layout

### DIFF
--- a/src/app/entrenamientos/page.tsx
+++ b/src/app/entrenamientos/page.tsx
@@ -2,7 +2,7 @@
 
 export default function Entrenamientos() {
   return (
-    <div className="bg-black text-white min-h-screen p-6">
+    <div className="bg-black text-white min-h-screen p-6 sm:p-4">
       <h1 className="text-3xl font-bold text-center mb-8">Entrenamientos</h1>
 
       <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
@@ -11,14 +11,12 @@ export default function Entrenamientos() {
           <h2 className="text-xl font-semibold mb-2">Cardio explosivo 🔥</h2>
           <p className="mb-4">Duración: 20 min · Nivel: Intermedio</p>
           <iframe
-            width="100%"
-            height="200"
             src="https://www.youtube.com/embed/dpHjK-RRAqA"
             title="Cardio explosivo"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-            className="rounded-md"
+            className="rounded-md w-full aspect-video"
           ></iframe>
         </div>
 
@@ -27,14 +25,12 @@ export default function Entrenamientos() {
           <h2 className="text-xl font-semibold mb-2">Fuerza sin pesas 💪</h2>
           <p className="mb-4">Duración: 30 min · Nivel: Principiante</p>
           <iframe
-            width="100%"
-            height="200"
             src="https://www.youtube.com/embed/UItWltVZZmE"
             title="Fuerza sin pesas"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-            className="rounded-md"
+            className="rounded-md w-full aspect-video"
           ></iframe>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
 
   return (
     <>
-      <div className="min-h-screen bg-black text-white flex flex-col items-center justify-center px-4 relative">
+      <div className="min-h-screen bg-black text-white flex flex-col items-center justify-center px-6 sm:px-4 relative">
         <h1 className="text-4xl font-bold text-center mb-8">Ronald Fitness Time</h1>
 
         <img
@@ -16,7 +16,7 @@ export default function Home() {
           className="rounded-xl mb-8 w-full max-w-md"
         />
 
-        <div className="flex flex-col gap-4 w-full max-w-xs">
+        <div className="flex flex-col gap-4 w-full max-w-xs mx-auto">
           <a href="/entrenamientos" className="bg-gray-200 text-black py-3 rounded-xl text-center">
             Ver entrenamientos
           </a>

--- a/src/app/reservar/page.tsx
+++ b/src/app/reservar/page.tsx
@@ -8,11 +8,13 @@ export default function Reservar() {
       </h1>
 
       {/* Calendly inline widget */}
-      <div
-        className="calendly-inline-widget mx-auto"
-        data-url="https://calendly.com/marito-dev/sesion-personal-60"
-        style={{ minWidth: '320px', height: '700px' }}
-      />
+      <div className="max-w-md w-full mx-auto px-4">
+        <div
+          className="calendly-inline-widget w-full"
+          data-url="https://calendly.com/marito-dev/sesion-personal-60"
+          style={{ minWidth: '320px', height: '700px' }}
+        />
+      </div>
 
       {/* Calendly script */}
       <Script

--- a/src/app/suscribirme/page.tsx
+++ b/src/app/suscribirme/page.tsx
@@ -1,7 +1,7 @@
 export default function Suscribirme() {
   return (
-    <main className="min-h-screen bg-black text-white flex items-center justify-center">
-      <h1 className="text-3xl font-bold">Unite semanalmente a los entrenamientos</h1>
+    <main className="min-h-screen bg-black text-white flex items-center justify-center p-6 sm:p-4">
+      <h1 className="text-3xl font-bold text-center">Unite semanalmente a los entrenamientos</h1>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- adjust padding on home page buttons
- prevent Calendly widget from shrinking
- enforce video aspect ratio
- tweak weekly training page spacing

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6871adc83244832da6d483886d4f2ef5