### PR TITLE
Add WhatsApp chat shortcut

### DIFF
--- a/components/WhatsAppButton.tsx
+++ b/components/WhatsAppButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { MessageCircle } from "lucide-react";
+
+const WhatsAppButton = () => {
+  const phoneNumber = "34610354194"; //
+  const message = encodeURIComponent("¡Hola Ronald! Estoy interesado en tus entrenamientos.");
+  const url = `https://wa.me/${phoneNumber}?text=${message}`;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-6 right-6 z-50 bg-green-500 hover:bg-green-600 text-white p-4 rounded-full shadow-lg transition-all duration-300 md:hidden"
+    >
+      <MessageCircle className="w-6 h-6" />
+    </a>
+  );
+};
+
+export default WhatsAppButton;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ronald-pwa",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "next-pwa": "^5.6.0",
         "react": "^19.0.0",
@@ -7094,6 +7095,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "next-pwa": "^5.6.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- add a WhatsApp floating action button
- install `lucide-react` icon package

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68723d6619bc832db79ba88f3befcfb4